### PR TITLE
Fix template serialization and Docker fallback

### DIFF
--- a/themes/reussitepersonnelle/templates/front-page.html
+++ b/themes/reussitepersonnelle/templates/front-page.html
@@ -21,7 +21,7 @@
 				<!-- /wp:paragraph -->
 
 				<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
-				<div class="wp-block-buttons" style="margin-top:var(--wp--custom--rp--space--3)">
+				<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">
 					<!-- wp:button -->
 					<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/blog/">Lire les articles</a></div>
 					<!-- /wp:button -->
@@ -43,15 +43,15 @@
 		<!-- wp:group {"align":"wide","className":"rp-signal-grid"} -->
 		<div class="wp-block-group alignwide rp-signal-grid">
 			<!-- wp:paragraph {"className":"rp-signal"} -->
-			<p class="rp-signal"><strong>Plus lucide</strong>Mettre des mots sur ce qui bloque avant de chercher une solution rapide.</p>
+			<p class="rp-signal"><strong>Plus lucide</strong> Mettre des mots sur ce qui bloque avant de chercher une solution rapide.</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"className":"rp-signal"} -->
-			<p class="rp-signal"><strong>Plus stable</strong>Construire des habitudes, des limites et une confiance qui tiennent dans la durée.</p>
+			<p class="rp-signal"><strong>Plus stable</strong> Construire des habitudes, des limites et une confiance qui tiennent dans la durée.</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"className":"rp-signal"} -->
-			<p class="rp-signal"><strong>Plus libre</strong>Avancer sans se laisser définir par la peur, le regard des autres ou les injonctions sociales.</p>
+			<p class="rp-signal"><strong>Plus libre</strong> Avancer sans se laisser définir par la peur, le regard des autres ou les injonctions sociales.</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
@@ -142,7 +142,7 @@
 				<!-- /wp:list -->
 
 				<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
-				<div class="wp-block-buttons" style="margin-top:var(--wp--custom--rp--space--3)">
+				<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">
 					<!-- wp:button {"className":"is-style-outline"} -->
 					<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="/a-propos/">Découvrir le site</a></div>
 					<!-- /wp:button -->

--- a/tools/local/docker-access.sh
+++ b/tools/local/docker-access.sh
@@ -37,6 +37,10 @@ rp_reexec_with_docker_group_if_needed() {
 		command_line+=" $quoted_arg"
 	done
 
+	if ! sg docker -c 'docker info >/dev/null 2>&1' >/dev/null 2>&1; then
+		return
+	fi
+
 	export RP_DOCKER_GROUP_SESSION=1
 	exec sg docker -c "$command_line"
 }


### PR DESCRIPTION
## Summary
- Align saved front-page button spacing with WordPress preset serialization.
- Add readable whitespace after front-page signal labels without changing visual layout.
- Guard Docker group re-exec so failed non-interactive group switching falls back to normal diagnostics.

## Validation
- Browser comparison against a DOM-mutated previous state: identical metrics and full-page screenshot bytes.
- `git diff --check`
- `bash -n tools/local/docker-access.sh tools/local/smoke-test.sh`
- `shellcheck tools/local/*.sh tools/sync/*.sh`
- `npm run lint:php`
- `npm run local:check`
- `npm run test:smoke`